### PR TITLE
🔧 adding virtual volume for sqlserver data

### DIFF
--- a/devops/docker/docker-compose.yml
+++ b/devops/docker/docker-compose.yml
@@ -22,3 +22,8 @@ services:
       - envs/sqlserver.env
     ports:
     - 1433:1433
+    volumes:
+      - sql-storage:/var/opt/mssql
+  
+volumes:
+  sql-storage:


### PR DESCRIPTION
Esse PR visa permitir que os dados relacionado ao SqlServer persistam no Docker em que ele estiver hospedado; 

### Contexto

Por equivoco meu indiquei uma referencia desatualizada do docker-compose.yml do banco de dados;
O detalhe é que na versão antiga, quando o docker ou o contêiner é reiniciado os bancos de dados são perdidos
